### PR TITLE
struct-to-config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -535,7 +535,9 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "serde_yaml_bw",
  "tester",
+ "toml",
  "tracing",
  "ureq",
  "util",
@@ -857,9 +859,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.11.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2481980430f9f78649238835720ddccc57e52df14ffce1c6f37391d61b563e9"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.5",
@@ -1526,6 +1528,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_yaml_bw"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4579b43e8ff40c1795b20ba915c0027bb011aed9c2fff606b2d2d7e74d7ad490"
+dependencies = [
+ "base64",
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1705,10 +1730,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "toml"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75129e1dc5000bfbaa9fee9d1b21f974f9fbad9daec557a521ee6e080825f6e8"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime 0.7.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bade1c3e902f58d73d3f294cd7f20391c1cb2fbcb643b73566bc773971df91e3"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "toml_edit"
@@ -1717,9 +1766,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
- "toml_datetime",
+ "toml_datetime 0.6.11",
  "winnow",
 ]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b551886f449aa90d4fe2bdaa9f4a2577ad2dde302c61ecf262d80b116db95c10"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc842091f2def52017664b53082ecbbeb5c7731092bad69d2c63050401dfd64"
 
 [[package]]
 name = "tracing"
@@ -1787,6 +1851,12 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/doers/Cargo.toml
+++ b/doers/Cargo.toml
@@ -19,6 +19,8 @@ rand = "0.9.2"
 regex = "1.11.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0.140"
+serde_yaml_bw = "2.1.3"
+toml = "0.9.5"
 tracing = "0.1.41"
 ureq = { version = "3", features = ["json"] }
 util = { path = "../util" }

--- a/doers/src/file.rs
+++ b/doers/src/file.rs
@@ -4,6 +4,7 @@ use blake3::Hash;
 use common::prelude::*;
 use regex::Regex;
 use serde::Deserialize;
+use serde_json::Value;
 use std::fmt::Debug;
 use std::fs;
 use std::io::Write;
@@ -28,6 +29,8 @@ pub struct DesiredFileState {
     pub content: Option<String>,
     pub ignore_pattern: Option<String>,
     pub from: Option<Utf8PathBuf>,
+    pub from_struct: Option<Value>,
+    pub to_format: Option<String>,
     pub backup_suffix: Option<String>,
 }
 
@@ -40,9 +43,16 @@ pub struct GurpFileRemove {
 }
 
 impl GurpFileEnsure {
-    fn content_xor_file(&self) -> bool {
-        (self.desired_state.content.is_some() && self.desired_state.from.is_none())
-            || (self.desired_state.content.is_none() && self.desired_state.from.is_some())
+    fn content_xor_file_xor_content_struct(&self) -> bool {
+        (self.desired_state.content.is_some()
+            && self.desired_state.from.is_none()
+            && self.desired_state.from_struct.is_none())
+            || (self.desired_state.content.is_none()
+                && self.desired_state.from.is_some()
+                && self.desired_state.from_struct.is_none())
+            || (self.desired_state.content.is_none()
+                && self.desired_state.from.is_none()
+                && self.desired_state.from_struct.is_some())
     }
 
     fn source_exists_if_needed(&self) -> bool {
@@ -60,6 +70,55 @@ impl GurpFileEnsure {
         }
     }
 
+    // Ini files can't nest structs. If we get anything we don't expect, error. This is very basic.
+    //
+    fn struct_to_ini(&self, value: &Value) -> anyhow::Result<String> {
+        let map = value
+            .as_object()
+            .ok_or_else(|| anyhow::anyhow!("Requested INI, but data is not a struct"))?;
+
+        let mut ret = String::new();
+
+        for (section_name, values) in map {
+            let section_map = values
+                .as_object()
+                .ok_or_else(|| anyhow::anyhow!("Section '{}' must be a struct", section_name))?;
+
+            if !ret.is_empty() {
+                ret.push('\n');
+            }
+
+            ret.push_str(&format!("[{section_name}]\n"));
+
+            for (k, v) in section_map {
+                let string_val = v.to_string().trim_matches('"').to_owned();
+                let value = if string_val.chars().all(|c| c.is_alphanumeric()) {
+                    string_val
+                } else {
+                    format!("\"{string_val}\"")
+                };
+
+                ret.push_str(&format!("{k} = {value}\n"));
+            }
+        }
+
+        Ok(ret)
+    }
+
+    fn struct_to_file(&self, value: &Value, format: Option<&str>) -> anyhow::Result<String> {
+        if let Some(format) = format {
+            match format.to_lowercase().as_str() {
+                "yaml" => Ok(serde_yaml_bw::to_string(&value)?),
+                "toml" => Ok(toml::to_string(&value)?),
+                "json" => Ok(serde_json::to_string_pretty(&value)?),
+                "ini" => Ok(self.struct_to_ini(value)?),
+                other => bail!("Unknown format: {}", other),
+            }
+        } else {
+            bail!("from_struct requires to_format")
+        }
+    }
+
     fn file_has_changed(&self) -> anyhow::Result<bool> {
         let (desired_hash, current_hash) = if let Some(pattern) = &self.desired_state.ignore_pattern
         {
@@ -68,6 +127,16 @@ impl GurpFileEnsure {
                     self.hash_of_filtered_file(from_file, pattern)?
                 } else if let Some(content) = &self.desired_state.content {
                     self.hash_of(&self.filter(content, pattern)?)
+                } else if let Some(from_struct) = &self.desired_state.from_struct {
+                    self.hash_of(
+                        &self.filter(
+                            &self.struct_to_file(
+                                from_struct,
+                                self.desired_state.to_format.as_deref(),
+                            )?,
+                            pattern,
+                        )?,
+                    )
                 } else {
                     bail!("No :content or :from")
                 },
@@ -79,6 +148,11 @@ impl GurpFileEnsure {
                     self.hash_of_file(from_file)?
                 } else if let Some(content) = &self.desired_state.content {
                     self.hash_of(content)
+                } else if let Some(from_struct) = &self.desired_state.from_struct {
+                    self.hash_of(
+                        &self
+                            .struct_to_file(from_struct, self.desired_state.to_format.as_deref())?,
+                    )
                 } else {
                     bail!("No :content or :from");
                 },
@@ -91,8 +165,8 @@ impl GurpFileEnsure {
 
     pub fn apply(&self, opts: &ApplyOpts) -> anyhow::Result<ApplySummary> {
         ensure!(
-            self.content_xor_file(),
-            "file '{}' must have exactly one of :content or :from",
+            self.content_xor_file_xor_content_struct(),
+            "file '{}' must have exactly one of :content, :from, or :from-struct",
             &self.path
         );
 
@@ -159,7 +233,11 @@ impl GurpFileEnsure {
 
         if let Some(from) = &self.desired_state.from {
             tracing::debug!("copying {} -> {}", from, self.path);
-            fs::copy(from, &self.path)?;
+
+            if !opts.noop {
+                fs::copy(from, &self.path)?;
+            }
+
             Ok(())
         } else if let Some(content) = &self.desired_state.content {
             tracing::debug!("Writing content to {}", self.path);
@@ -170,8 +248,20 @@ impl GurpFileEnsure {
             }
 
             Ok(())
+        } else if let Some(from_struct) = &self.desired_state.from_struct {
+            tracing::debug!("Writing file from struct to {}", self.path);
+
+            let content =
+                self.struct_to_file(from_struct, self.desired_state.to_format.as_deref())?;
+
+            if !opts.noop {
+                let mut fh = fs::File::create(&self.path)?;
+                fh.write_all(content.as_bytes())?;
+            }
+
+            Ok(())
         } else {
-            bail!("can write neither :from nor :content");
+            bail!("nothing to write. Require :from, :content, or :from-struct");
         }
     }
 
@@ -230,10 +320,11 @@ impl GurpFileRemove {
 #[cfg(test)]
 mod test {
     use super::*;
-    use assert_fs::prelude::*;
     use assert_fs::TempDir;
+    use assert_fs::prelude::*;
     use camino::Utf8PathBuf;
-    use indoc::formatdoc;
+    use indoc::{formatdoc, indoc};
+    use pretty_assertions::assert_eq;
     use std::fs;
     use std::os::unix::fs::PermissionsExt;
     use tester::{defopts, defopts_noop, fixture, janet2json, my_group, my_user};
@@ -243,13 +334,13 @@ mod test {
         let temp = TempDir::new().unwrap();
         let path = Utf8PathBuf::from_path_buf(temp.child("test-file").to_path_buf()).unwrap();
 
-        let json_def = janet2json(&formatdoc! {"
-            (file/ensure \"{}\"
-                :content \"some-junk\"
-                :mode \"0750\"
-                :owner \"{}\"
-                :group \"{}\")
-            ",
+        let json_def = janet2json(&formatdoc! {r#"
+            (file/ensure "{}"
+                :content "some-junk"
+                :mode "0750"
+                :owner "{}"
+                :group "{}")
+            "#,
             path,
             my_user(),
             my_group(),
@@ -268,13 +359,13 @@ mod test {
         let path = Utf8PathBuf::from_path_buf(file.to_path_buf()).unwrap();
         assert!(!path.exists());
 
-        let json_def = janet2json(&formatdoc! {"
-            (file/ensure \"{}\"
-                :content \"stuff\"
-                :mode \"0640\"
-                :owner \"{}\"
-                :group \"{}\")
-            ",
+        let json_def = janet2json(&formatdoc! {r#"
+            (file/ensure "{}"
+                :content "stuff"
+                :mode "0640"
+                :owner "{}"
+                :group "{}")
+            "#,
             path,
             my_user(),
             my_group(),
@@ -308,6 +399,8 @@ mod test {
                 ignore_pattern: None,
                 from: Some(fixture("file/binary-file")),
                 backup_suffix: None,
+                from_struct: None,
+                to_format: None,
             },
         };
 
@@ -333,6 +426,8 @@ mod test {
                 ignore_pattern: None,
                 from: Some(fixture("file/binary-file")),
                 backup_suffix: None,
+                from_struct: None,
+                to_format: None,
             },
         };
 
@@ -350,14 +445,14 @@ mod test {
         assert!(!path.exists());
 
         // escape { with another {
-        let json_def = janet2json(&formatdoc! {"
-            (file/ensure \"{}\"
-                :content (template-out \"{{{{ name }}}} is running a {{{{ thing }}}}\"
-                                        {{ :name \"gurp\" :thing \"test\" }})
-                :mode \"0600\"
-                :owner \"{}\"
-                :group \"{}\")
-            ",
+        let json_def = janet2json(&formatdoc! {r#"
+            (file/ensure "{}"
+                :content (template-out "{{{{ name }}}} is running a {{{{ thing }}}}"
+                                        {{ :name "gurp" :thing "test" }})
+                :mode "0600"
+                :owner "{}"
+                :group "{}")
+            "#,
             path,
             my_user(),
             my_group(),
@@ -372,6 +467,126 @@ mod test {
     }
 
     #[test]
+    fn test_file_create_json_from_struct() {
+        let temp = TempDir::new().unwrap();
+        let file = temp.join("test-file");
+        let path = Utf8PathBuf::from_path_buf(file.to_path_buf()).unwrap();
+        assert!(!path.exists());
+
+        let expected = indoc! { r#"
+                {
+                  "my-arr": [
+                    "abc",
+                    "def",
+                    "ghi"
+                  ],
+                  "my-str": "I am a String",
+                  "my-struct": {
+                    "key_1": "val 1",
+                    "key_2": 123,
+                    "key_3": [
+                      456,
+                      789
+                    ]
+                  }
+                }"#};
+
+        let sut: GurpFileEnsure = serde_json::from_str(&sample_struct(&path, "json")).unwrap();
+        assert_eq!(ONE_RESOURCE_ONE_CHANGE, sut.apply(&defopts()).unwrap());
+        assert!(path.exists());
+        let metadata = fs::metadata(&path).unwrap();
+        assert_eq!(metadata.permissions().mode() & 0o7777, 0o600);
+        assert_eq!(expected, fs::read_to_string(path).unwrap());
+    }
+
+    #[test]
+    fn test_file_create_yaml_from_struct() {
+        let temp = TempDir::new().unwrap();
+        let file = temp.join("test-file");
+        let path = Utf8PathBuf::from_path_buf(file.to_path_buf()).unwrap();
+        assert!(!path.exists());
+
+        let expected = indoc! { r#"
+            my-arr:
+            - abc
+            - def
+            - ghi
+            my-str: I am a String
+            my-struct:
+              key_1: val 1
+              key_2: 123
+              key_3:
+              - 456
+              - 789
+          "#};
+
+        let sut: GurpFileEnsure = serde_json::from_str(&sample_struct(&path, "yaml")).unwrap();
+        assert_eq!(ONE_RESOURCE_ONE_CHANGE, sut.apply(&defopts()).unwrap());
+        assert!(path.exists());
+        let metadata = fs::metadata(&path).unwrap();
+        assert_eq!(metadata.permissions().mode() & 0o7777, 0o600);
+        assert_eq!(expected, fs::read_to_string(path).unwrap());
+    }
+
+    #[test]
+    fn test_file_create_ini_from_struct() {
+        let temp = TempDir::new().unwrap();
+        let file = temp.join("test-file");
+        let path = Utf8PathBuf::from_path_buf(file.to_path_buf()).unwrap();
+        assert!(!path.exists());
+
+        let json_def = janet2json(&formatdoc! {r#"
+            (file/ensure "{path}"
+                :from-struct {{
+                    :section_1 {{
+                        :key_1 "A spacey string"
+                        :key_2 123
+                        :key_3 false
+                        :key_4 "word"
+                    }}
+                    :section_2 {{
+                        :key_1 "merp"
+                        :key_2 "gurp"
+                    }}
+                }}
+                :to-format "ini"
+                :mode "0600"
+                :owner "{user}"
+                :group "{group}")
+            "#,
+            path = path,
+            user = my_user(),
+            group = my_group(),
+        });
+
+        let expected = indoc! { r#"
+                [section_1]
+                key_1 = "A spacey string"
+                key_2 = 123
+                key_3 = false
+                key_4 = word
+
+                [section_2]
+                key_1 = merp
+                key_2 = gurp
+        "#};
+
+        let sut: GurpFileEnsure = serde_json::from_str(&json_def).unwrap();
+        assert_eq!(ONE_RESOURCE_ONE_CHANGE, sut.apply(&defopts()).unwrap());
+        assert!(path.exists());
+        let metadata = fs::metadata(&path).unwrap();
+        assert_eq!(metadata.permissions().mode() & 0o7777, 0o600);
+        assert_eq!(expected, fs::read_to_string(path).unwrap());
+    }
+
+    #[test]
+    fn test_file_create_ini_from_struct_errors() {
+        let sut: GurpFileEnsure =
+            serde_json::from_str(&sample_struct(&Utf8PathBuf::from("/tmp/file"), "ini")).unwrap();
+        assert!(sut.apply(&defopts()).is_err());
+    }
+
+    #[test]
     fn test_file_ensure_already_correct() {
         let temp = TempDir::new().unwrap();
         temp.child("test-file").write_str("stuff").unwrap();
@@ -381,13 +596,13 @@ mod test {
         fs::set_permissions(&path, fs::Permissions::from_mode(0o0750)).unwrap();
         assert!(path.exists());
 
-        let json_def = janet2json(&formatdoc! {"
-            (file/ensure \"{}\"
-                :content \"stuff\"
-                :mode \"0750\"
-                :owner \"{}\"
-                :group \"{}\")
-            ",
+        let json_def = janet2json(&formatdoc! {r#"
+            (file/ensure "{}"
+                :content "stuff"
+                :mode "0750"
+                :owner "{}"
+                :group "{}")
+            "#,
             path,
             my_user(),
             my_group(),
@@ -410,13 +625,13 @@ mod test {
             .join("test-file");
         assert!(path.exists());
 
-        let json_def = janet2json(&formatdoc! {"
-            (file/ensure \"{}\"
-                :content \"the-right-stuff\"
-                :mode \"0400\"
-                :owner \"{}\"
-                :group \"{}\")
-            ",
+        let json_def = janet2json(&formatdoc! {r#"
+            (file/ensure "{}"
+                :content "the-right-stuff"
+                :mode "0400"
+                :owner "{}"
+                :group "{}")
+            "#,
             path,
             my_user(),
             my_group(),
@@ -448,13 +663,13 @@ mod test {
 
         assert!(path.exists());
 
-        let json_def = janet2json(&formatdoc! {"
-            (file/ensure \"{}\"
-                :from \"{}\"
-                :mode \"0444\"
-                :owner \"{}\"
-                :group \"{}\")
-            ",
+        let json_def = janet2json(&formatdoc! {r#"
+            (file/ensure "{}"
+                :from "{}"
+                :mode "0444"
+                :owner "{}"
+                :group "{}")
+            "#,
             path,
             &fixture("file/copy-file"),
             my_user(),
@@ -518,14 +733,14 @@ mod test {
         fs::set_permissions(&path, fs::Permissions::from_mode(0o600)).unwrap();
         assert!(path.exists());
 
-        let json_def = janet2json(&formatdoc! {"
-            (file/ensure \"{}\"
-                :from \"{}\"
-                :mode \"0600\"
-                :ignore-pattern \"^today is\"
-                :owner \"{}\"
-                :group \"{}\")
-            ",
+        let json_def = janet2json(&formatdoc! {r#"
+            (file/ensure "{}"
+                :from "{}"
+                :mode "0600"
+                :ignore-pattern "^today is"
+                :owner "{}"
+                :group "{}")
+            "#,
             path,
             fixture("file/ignore-line-file"),
             my_user(),
@@ -585,5 +800,29 @@ mod test {
         let sut: GurpFileRemove = serde_json::from_str(&json_def).unwrap();
         assert_eq!(ONE_RESOURCE_NOOP, sut.apply(&defopts_noop()).unwrap());
         assert!(path.exists());
+    }
+
+    fn sample_struct(path: &Utf8PathBuf, format: &str) -> String {
+        janet2json(&formatdoc! {r#"
+            (file/ensure "{path}"
+                :from-struct {{
+                    :my-struct {{
+                        :key_1 "val 1"
+                        :key_2 123
+                        :key_3 [456 789]
+                    }}
+                    :my-arr ["abc" "def" "ghi"]
+                    :my-str "I am a String"
+                }}
+                :to-format "{format}"
+                :mode "0600"
+                :owner "{user}"
+                :group "{group}")
+            "#,
+            path = path,
+            format = format,
+            user = my_user(),
+            group = my_group(),
+        })
     }
 }

--- a/janet_src/lib/gurp.janet
+++ b/janet_src/lib/gurp.janet
@@ -52,6 +52,8 @@
      :owner ["The username or UID of the user who owns this file" :string :number]
      :content ["Literal content of the file. Must have :content xor :from" :string]
      :from ["Copy content from this file. If relative, looks in ../files" :string]
+     :from-struct ["Generate a config file from the given struct. Requires :to-format" :struct]
+     :to-format ["Used with :from-struct to try to turn the struct into this format" : string]
      :ignore-pattern ["When comparing, ignore lines matching this Rust regex" :string]}}
 
    :gem
@@ -279,28 +281,28 @@
 (defn- resolve-reference
   "Recursively chase down references. Catches circular and dangling"
   [target flat-resources seen]
-  (try 
-  (let [last-sep (last (string/find-all "/" target))
-        chunks (string/split "/" target last-sep)
-        id (first chunks)
-        field (keyword (last chunks))
-        referenced-struct (find |(= id (get $ :_id)) flat-resources)]
+  (try
+    (let [last-sep (last (string/find-all "/" target))
+          chunks (string/split "/" target last-sep)
+          id (first chunks)
+          field (keyword (last chunks))
+          referenced-struct (find |(= id (get $ :_id)) flat-resources)]
 
-    (if (nil? referenced-struct)
-      (error (string/format "Referenced resource '%s' not found" id)))
+      (if (nil? referenced-struct)
+        (error (string/format "Referenced resource '%s' not found" id)))
 
-    (if (has-value? seen id)
-      (error (string/format "Detected circular reference [%q]" seen)))
+      (if (has-value? seen id)
+        (error (string/format "Detected circular reference [%q]" seen)))
 
-    (set (seen id) true)
-    (def referenced-val (referenced-struct field))
+      (set (seen id) true)
+      (def referenced-val (referenced-struct field))
 
-    (if (keyword? referenced-val)
-      (resolve-reference referenced-val flat-resources seen)
-      referenced-val))
-      ([e]
-        (error
-          (string "Failed to resolve reference '" target "'")))))
+      (if (keyword? referenced-val)
+        (resolve-reference referenced-val flat-resources seen)
+        referenced-val))
+    ([e]
+      (error
+        (string "Failed to resolve reference '" target "'")))))
 
 (defn- resolve-resource-references
   "Update any references in a resource with their final targets"


### PR DESCRIPTION
Adds two new keys to the file doer. `:from-struct` can be used in place of `:from` or `:content`, and must be paired with a Janet struct. You must also supply a `:to-format` value, which can be one of `json`, `yaml`, `toml`, or `ini`. Gurp will convert your struct to that format.

Note that INI files are limited in that they have to be sections of key value pairs, so your input must be of the form

```janet
{:section-1 {:key-1 "val1" :key-2 "val2}
 :section-2 {:key-1 "val1"}}
```