### PR TITLE
properly trap Janet compile-time errors, and act accordingly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -962,6 +962,7 @@ dependencies = [
  "anyhow",
  "build_helper",
  "camino",
+ "camino-tempfile",
  "common",
  "indoc",
  "janetrs",

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,7 +5,7 @@
 - Add `-S, --splay <SPLAY>` to `apply` command. Pauses a random number of
   seconds up to a given maximum before applying. Splay can also be set via
   control-data.
-- Improve detection and handling of Janet compilation errors.
+- Improve detection, handling, and logging, of Janet compilation errors.
 
 ## v2.1.0 (2026-06-16)
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,6 +5,7 @@
 - Add `-S, --splay <SPLAY>` to `apply` command. Pauses a random number of
   seconds up to a given maximum before applying. Splay can also be set via
   control-data.
+- Improve detection and handling of Janet compilation errors.
 
 ## v2.1.0 (2026-06-16)
 

--- a/cli/tests/apply.rs
+++ b/cli/tests/apply.rs
@@ -38,6 +38,6 @@ mod test {
             .arg("./tests/resources/bad.janet")
             .assert()
             .failure()
-            .stderr(predicate::str::contains("unknown symbol physical"));
+            .stdout(predicate::str::contains("unknown symbol physical"));
     }
 }

--- a/cli/tests/compile.rs
+++ b/cli/tests/compile.rs
@@ -89,7 +89,7 @@ mod test {
             .arg("tests/resources/bad.janet")
             .assert()
             .failure()
-            .stderr(predicate::str::contains(
+            .stdout(predicate::str::contains(
                 "compile error: unknown symbol physical",
             ));
     }

--- a/commands/src/apply/command.rs
+++ b/commands/src/apply/command.rs
@@ -148,11 +148,11 @@ mod test {
             )
         );
 
-        // assert!(logs_contain(
-        //     "could not generate config: compilation error: Failed to parse code"
-        // ));
-        // assert!(logs_contain("sending fail metrics: compile"));
-        // assert!(!logs_contain("resources:"));
+        assert!(logs_contain(
+            "could not generate config: compile error: Failed to parse code"
+        ));
+        assert!(logs_contain("sending fail metrics: compile"));
+        assert!(!logs_contain("resources:"));
     }
 
     #[test]
@@ -218,7 +218,9 @@ mod test {
         );
 
         assert!(logs_contain(
-            "could not generate config: compilation error: Runtime VM error"
+            "ERROR file_does_not_compile: commands::apply::command: could not generate \
+            config: compilation error: In directory/ensure /tmp/testdir: unexpected \
+            property :bad-key."
         ));
         assert!(logs_contain("sending fail metrics: compile"));
         assert!(!logs_contain("resources:"));

--- a/commands/src/apply/command.rs
+++ b/commands/src/apply/command.rs
@@ -148,11 +148,11 @@ mod test {
             )
         );
 
-        assert!(logs_contain(
-            "could not generate config: compilation error: Failed to parse code"
-        ));
-        assert!(logs_contain("sending fail metrics: compile"));
-        assert!(!logs_contain("resources:"));
+        // assert!(logs_contain(
+        //     "could not generate config: compilation error: Failed to parse code"
+        // ));
+        // assert!(logs_contain("sending fail metrics: compile"));
+        // assert!(!logs_contain("resources:"));
     }
 
     #[test]

--- a/commands/src/apply/command.rs
+++ b/commands/src/apply/command.rs
@@ -3,7 +3,7 @@ use super::{config, lockfile, metrics};
 use crate::apply::types::{ApplyStatus, FailPhase};
 use camino::{Utf8Path, Utf8PathBuf};
 use chrono::Utc;
-use common::types::ApplyOpts;
+use common::types::{ApplyOpts, CompileError};
 use doers::types::Applicator;
 use gurptel::{flush, types::TelemetryProviders};
 use std::process::ExitCode;
@@ -89,6 +89,15 @@ pub fn run(
 
         Err(e) => {
             tracing::error!("could not generate config: {e:#}");
+
+            if let CompileError::Compile { message, trace } = &e {
+                if message.contains("unknown symbol machine-config") {
+                    tracing::error!("config may lack a (host) definition");
+                };
+
+                tracing::debug!(janet_trace = trace.join("\n"));
+            };
+
             metrics::send(ApplyStatus::Fail(e.into()), &start_time.elapsed());
             ExitCode::FAILURE
         }

--- a/commands/src/apply/config.rs
+++ b/commands/src/apply/config.rs
@@ -97,3 +97,8 @@ pub(crate) fn compile(
 
     Ok(json_config)
 }
+
+#[cfg(test)]
+mod test {
+    // TODO test failure modes
+}

--- a/commands/src/apply/types.rs
+++ b/commands/src/apply/types.rs
@@ -39,9 +39,12 @@ impl From<CompileError> for FailPhase {
             },
             CompileError::FileNotFound(_) => FailPhase::FileNotFound,
             CompileError::ClientCreate(_) => FailPhase::Client,
-            CompileError::Compile(_) => FailPhase::Compile,
             CompileError::Other(_) => FailPhase::Compile,
             CompileError::Io(_) => FailPhase::Compile,
+            CompileError::Compile {
+                message: _,
+                trace: _,
+            } => FailPhase::Compile,
         }
     }
 }

--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -95,8 +95,8 @@ impl AddAssign for ApplySummary {
 /// Compilation can fail at numerous points. We use this enum to tell the user where.
 #[derive(Debug, thiserror::Error)]
 pub enum CompileError {
-    #[error("compilation error: {0}")]
-    Compile(#[source] anyhow::Error),
+    #[error("compilation error: {message}")]
+    Compile { message: String, trace: Vec<String> },
     #[error("network error: {0}")]
     Network(#[source] NetworkError),
     #[error("I/O error: {0}")]

--- a/doers/src/types.rs
+++ b/doers/src/types.rs
@@ -33,7 +33,7 @@ use anyhow::{Context, bail};
 use bytesize::ByteSize;
 use camino::Utf8PathBuf;
 use colored::Colorize;
-use common::types::{ApplyOpts, ApplySummary, ChangedIds};
+use common::types::{ApplyOpts, ApplySummary, ChangedIds, JsonConfig};
 use gurptel::runtime_stats;
 use rand::RngExt;
 use regex::Regex;
@@ -275,7 +275,7 @@ pub struct Applicator {
 }
 
 impl Applicator {
-    pub fn from(json_config: String) -> Self {
+    pub fn from(json_config: JsonConfig) -> Self {
         Self { json_config }
     }
 
@@ -328,6 +328,8 @@ impl Applicator {
             "Unpacking {} bytes of JSON config into HostConfig",
             self.json_config.len()
         );
+
+        tracing::debug!("Raw JSON is {}", self.json_config);
 
         let host_config: HostConfig = match serde_json::from_str(&self.json_config) {
             Ok(conf) => conf,
@@ -503,6 +505,7 @@ impl Applicator {
         Ok(summary_total)
     }
 
+    // This should only handle deserialing errors.
     fn display_error(&self, e: Error) -> anyhow::Result<()> {
         tracing::error!("deserializing error: {}", e);
 
@@ -524,4 +527,9 @@ impl Applicator {
 
         Ok(())
     }
+}
+
+#[cfg(test)]
+mod test {
+    // TODO we need tests for various fail modes.
 }

--- a/embed/Cargo.toml
+++ b/embed/Cargo.toml
@@ -18,4 +18,5 @@ build_helper = { path = "../build_helper" }
 walkdir = "2.5.0"
 
 [dev-dependencies]
+camino-tempfile = "1.4.1"
 pretty_assertions = "1.4.1"

--- a/embed/src/compiler.rs
+++ b/embed/src/compiler.rs
@@ -340,19 +340,19 @@ mod test {
         );
     }
 
-    // #[test]
-    // fn test_snippet_is_not_even_janet() {
-    //     let err = test_compiler().janet_snippet("123abc").unwrap_err();
+    #[test]
+    fn test_snippet_is_not_even_janet() {
+        let err = test_compiler().janet_snippet("123abc").unwrap_err();
 
-    //     // match err {
-    //     //     CompileError::Compile { message, trace } => {
-    //     //         assert_eq!("merp", message);
-    //     //     }
-    //     //     other => {
-    //     //         panic!("expected CompileError::Compile, got {other:?}");
-    //     //     }
-    //     // }
-    // }
+        match err {
+            CompileError::Other(e) => {
+                assert_eq!("Failed to parse code", e.to_string());
+            }
+            other => {
+                panic!("expected CompileError::Compile, got {other:?}");
+            }
+        }
+    }
 
     fn test_compiler() -> ConfigCompiler {
         ConfigCompiler::new(&ApplyVmOpts::default(), false, ApplyOutputOpts::default()).unwrap()

--- a/embed/src/compiler.rs
+++ b/embed/src/compiler.rs
@@ -316,12 +316,12 @@ mod test {
     #[test]
     fn test_file_is_not_even_janet() {
         let err = test_compiler()
-            .janet_file("/etc/passwd".into(), true)
+            .janet_file(&fixture("not_even_janet.janet"), true)
             .unwrap_err();
 
         match err {
             CompileError::Compile { message, trace } => {
-                assert!(message.contains("parse error"));
+                assert!(message.contains("compile error: unknown symbol"));
                 assert!(!trace.is_empty());
             }
             other => {

--- a/embed/src/compiler.rs
+++ b/embed/src/compiler.rs
@@ -6,7 +6,7 @@ use common::info;
 use common::types::{ApplyOutputOpts, ApplyVmOpts, CompileError, JsonConfig};
 use janetrs::client::JanetClient;
 use janetrs::env::DefOptions;
-use janetrs::{Janet, JanetString, TaggedJanet};
+use janetrs::{Janet, JanetString, JanetStruct, TaggedJanet};
 use std::env;
 
 /// A JsonCompiler turns Janet config into a JSON string
@@ -47,9 +47,9 @@ impl ConfigCompiler {
             .map_err(CompileError::Other)?;
 
         let final_cmd = if to_json {
-            "(to-json (machine-config))"
+            "(to-json (eval '(machine-config)))"
         } else {
-            "(machine-config)"
+            "(eval '(machine-config))"
         };
 
         let janet_instructions = indoc::formatdoc! { r#"
@@ -122,29 +122,95 @@ impl ConfigCompiler {
     // Wrapper for compile() for when we want to get a JSON string
     fn compile_to_string(&self, code: &str) -> Result<JsonConfig, CompileError> {
         compile(&self.client, code)
-            .and_then(|bytes| String::from_utf8(bytes).map_err(|e| CompileError::Compile(e.into())))
+            .and_then(|bytes| String::from_utf8(bytes).map_err(|e| CompileError::Other(e.into())))
     }
 }
-//
+
+/// Trying to compile invalid Janet causes a Janet panic, with a stack trace
+/// dumped to stderr. We want to capture the error so we can act accordingly,
+/// and the stack trace so we can pass it back to a client from a server.
+///
+/// To do this we wrap the Janet so it runs in a fiber. Said fiber receives
+/// the current environment as `outer-env` (which is resumed after the Janet
+/// runs)
+///
+/// If the fiber errors,
+/// `debug/stacktrace` puts the trace into a buffer (using
+/// `with-dyns` to `:err`).The buffer is prefixed with
+///
+/// If the fiber completes without error, the wrapped code's own result is
+/// returned unchanged.
+///
+fn wrapped_config(code: &str) -> String {
+    indoc::formatdoc! { r#"
+    (def outer-env (curenv))
+    (def fib (fiber/new (fn [] {code}) :e outer-env))
+    (def result (resume fib))
+
+    (if (= (fiber/status fib) :error)
+      (let [buf @""]
+        (with-dyns [:err buf] (debug/stacktrace fib result ""))
+        (struct :error (string result) :trace (string buf)))
+      result)"# 
+    }
+}
+
+// Errors are wrapped now. They come in a struct with keys
+// :error and :trace.
+fn destructure_wrapped_error(st: JanetStruct) -> CompileError {
+    let jerror = match st.get_owned(":error") {
+        Some(err_msg) => err_msg.to_string(),
+        None => {
+            return CompileError::Other(anyhow::anyhow!(
+                "could not get error field from Janet result struct"
+            ));
+        }
+    };
+
+    let jtrace = match st.get_owned(":trace") {
+        Some(trace) => trace
+            .to_string()
+            .split('\n')
+            .map(|s| s.to_owned())
+            .collect(),
+        None => {
+            return CompileError::Other(anyhow::anyhow!(
+                "could not get trace field from Janet result struct"
+            ));
+        }
+    };
+
+    CompileError::Compile {
+        message: jerror,
+        trace: jtrace,
+    }
+}
+
 // Compile to a Vec<u8>, which can hold a jimage or be converted to a string, which we do
 // if we expect JSON output.
 fn compile(client: &JanetClient, code: &str) -> Result<Vec<u8>, CompileError> {
     tracing::debug!("evaluating Janet config");
+    let wrapped_code = wrapped_config(code);
 
-    match client.run(code) {
+    match client.run(&wrapped_code) {
         Ok(buf) => match buf.unwrap() {
-            TaggedJanet::String(s) => Ok(s.bytes().collect()),
+            // Successful compilation to JSON gives us a JSON String
+            TaggedJanet::String(str) => Ok(str.bytes().collect()),
+            // Successful compilation to an image gives us a Buffer
             TaggedJanet::Buffer(buf) => {
                 let bytes = buf.as_bytes();
                 if bytes.starts_with(b"ERR:") {
                     let msg = String::from_utf8_lossy(&bytes[4..]).into_owned();
-                    Err(CompileError::Compile(anyhow::anyhow!(msg)))
+                    Err(CompileError::Other(anyhow::anyhow!(msg)))
                 } else {
                     Ok(bytes.to_vec())
                 }
-            } //
-            _ => Err(CompileError::Compile(anyhow::anyhow!(
-                "Janet eval returned unexpected type: expected Buffer, got {buf:?}"
+            }
+            // A compilation error gives us a struct
+            TaggedJanet::Struct(jstruct) => Err(destructure_wrapped_error(jstruct)),
+            // We shouldn't see anything else
+            _ => Err(CompileError::Other(anyhow::anyhow!(
+                "Janet eval returned unexpected type: expected String or Struct, got {buf:?}"
             ))),
         },
         Err(e) => {
@@ -154,11 +220,11 @@ fn compile(client: &JanetClient, code: &str) -> Result<Vec<u8>, CompileError> {
                 janetrs::client::Error::EnvNotInit => "EnvNotInit",
                 janetrs::client::Error::ParseError => "ParseError",
                 janetrs::client::Error::RunError => "RunError",
-                _ => "<UNKNOWN>", // Should be impossible
+                _ => "<UNKNOWN>",
             };
 
-            tracing::error!("error compiling Janet config: {err_desc}");
-            Err(CompileError::Compile(e.into()))
+            tracing::error!("unhandled error compiling Janet config: {err_desc}");
+            Err(CompileError::Other(e.into()))
         }
     }
 }
@@ -193,8 +259,10 @@ pub fn to_jimage(path: &Utf8Path) -> Result<Vec<u8>, CompileError> {
 mod test {
     use super::*;
     use crate::tester::fixture;
+    use camino_tempfile::NamedUtf8TempFile;
     use common::types::ApplyVmOpts;
     use std::fs;
+    use std::io::Write;
 
     fn test_compiler() -> ConfigCompiler {
         ConfigCompiler::new(&ApplyVmOpts::default(), false, ApplyOutputOpts::default()).unwrap()
@@ -234,5 +302,40 @@ mod test {
                 .janet_image(&fs::read(fixture("basic_image.jimage")).unwrap(), None)
                 .unwrap()
         );
+    }
+
+    #[test]
+    fn test_file_is_bad_janet() {
+        let mut file = NamedUtf8TempFile::new().unwrap();
+        write!(file, "(unknown-function)").unwrap();
+
+        let err = test_compiler().janet_file(file.path(), true).unwrap_err();
+
+        match err {
+            CompileError::Compile { message, trace } => {
+                assert!(message.contains("compile error: unknown symbol unknown-function"));
+                assert!(!trace.is_empty());
+            }
+            other => {
+                panic!("expected CompileError::Compile, got {other:?}");
+            }
+        }
+    }
+
+    #[test]
+    fn test_file_is_not_even_janet() {
+        let err = test_compiler()
+            .janet_file("/etc/passwd".into(), true)
+            .unwrap_err();
+
+        match err {
+            CompileError::Compile { message, trace } => {
+                assert!(message.contains("parse error"));
+                assert!(!trace.is_empty());
+            }
+            other => {
+                panic!("expected CompileError::Compile, got {other:?}");
+            }
+        }
     }
 }

--- a/embed/src/compiler.rs
+++ b/embed/src/compiler.rs
@@ -121,8 +121,13 @@ impl ConfigCompiler {
 
     // Wrapper for compile() for when we want to get a JSON string
     fn compile_to_string(&self, code: &str) -> Result<JsonConfig, CompileError> {
-        compile(&self.client, code)
-            .and_then(|bytes| String::from_utf8(bytes).map_err(|e| CompileError::Other(e.into())))
+        let compiled_bytes = compile(&self.client, code)?;
+
+        String::from_utf8(compiled_bytes).map_err(|e| {
+            CompileError::Other(anyhow::anyhow!(
+                "cannot convert compiled bytes to JSON string: {e}"
+            ))
+        })
     }
 }
 
@@ -264,26 +269,12 @@ mod test {
     use std::fs;
     use std::io::Write;
 
-    fn test_compiler() -> ConfigCompiler {
-        ConfigCompiler::new(&ApplyVmOpts::default(), false, ApplyOutputOpts::default()).unwrap()
-    }
-
     #[test]
     fn test_janet_file() {
         assert_eq!(
             r#"{"control-data":{},"metadata":{"name":"test"},"resources":{"ensure":{"file":[{"_id":"/basenode/file/_tmp_tester","content":"blah","group":"root","mode":"0644","name":"/tmp/tester","owner":"root","role":"basenode"}]},"remove":{}}}"#,
             test_compiler()
                 .janet_file(&fixture("basic_config.janet"), true)
-                .unwrap()
-        );
-    }
-
-    #[test]
-    fn test_janet_snippet() {
-        assert_eq!(
-            r#"{"control-data":{},"metadata":{"name":"gurp-runner"},"resources":{"ensure":{"directory":[{"_id":"/NO-ROLE/directory/_tmp_test1","group":"root","mode":"0755","name":"/tmp/test1","owner":"root","role":"NO-ROLE"}]},"remove":{}}}"#,
-            test_compiler()
-                .janet_snippet(r#"(directory/ensure "/tmp/test1")"#)
                 .unwrap()
         );
     }
@@ -337,5 +328,33 @@ mod test {
                 panic!("expected CompileError::Compile, got {other:?}");
             }
         }
+    }
+
+    #[test]
+    fn test_janet_snippet() {
+        assert_eq!(
+            r#"{"control-data":{},"metadata":{"name":"gurp-runner"},"resources":{"ensure":{"directory":[{"_id":"/NO-ROLE/directory/_tmp_test1","group":"root","mode":"0755","name":"/tmp/test1","owner":"root","role":"NO-ROLE"}]},"remove":{}}}"#,
+            test_compiler()
+                .janet_snippet(r#"(directory/ensure "/tmp/test1")"#)
+                .unwrap()
+        );
+    }
+
+    // #[test]
+    // fn test_snippet_is_not_even_janet() {
+    //     let err = test_compiler().janet_snippet("123abc").unwrap_err();
+
+    //     // match err {
+    //     //     CompileError::Compile { message, trace } => {
+    //     //         assert_eq!("merp", message);
+    //     //     }
+    //     //     other => {
+    //     //         panic!("expected CompileError::Compile, got {other:?}");
+    //     //     }
+    //     // }
+    // }
+
+    fn test_compiler() -> ConfigCompiler {
+        ConfigCompiler::new(&ApplyVmOpts::default(), false, ApplyOutputOpts::default()).unwrap()
     }
 }

--- a/embed/tests/resources/not_even_janet.janet
+++ b/embed/tests/resources/not_even_janet.janet
@@ -1,0 +1,1 @@
+this is just some normal text. It's not even Janet!


### PR DESCRIPTION
This is quite a big change. It uses some slightly hairy Janet fiber chicanery to capture error messages in the config compilation phase. The embedded interpreter normally dumps errors and stack traces to stderr, and capturing stderr from inside a Rust process is *really* horrible.

I think this is an improvement for the better, but I made a similar change once before and ended up reverting it. Hopefully this change uses the lessons from the previous change well.